### PR TITLE
Build offensive playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,104 @@
 # football-play-simulator
 Program to simulate American Football plays
 
-## User Inputs
+## Menu
 
-Keyboard
-- enter: will restart the play
-- spacebar: will pause the program
+### Menu Items
 
-Mouse:
-- left click: will unpause the program
+#### Menu Order
+Cycle through the different menus with ESC key
 
+View Plays in Offensive Playbook -> View Offensive Formations -> Build Offensive Playbook -> Run Offensive Plays in Playbook
+/ \
+ |___________________________________________________________________________________________________________|
+
+#### View Plays in Offensive Playbook
+View the plays in the default offensive playbook
+- Controls
+  - left / right: cycles through all of the plays
+
+#### View Offensive Formations
+View all of the built in offensive formations
+- Controls
+  - left / right: cycles through all of the offensive formations
+
+#### Build Offensive Playbook
+Build an offensive playbook by first selecting your offensive formation then the route for each player.
+
+Flow for building a playbook
+- First - "Formation": select the formation for the play
+  - Controls:
+    - enter - move to next step (select route for each player)
+    - up / down - cycle through all the available formations
+- Second - "Routes": select the route per player in the formation
+  - Route is displayed in red on the field in front of the player
+    Shows selected routes for each player in yellow
+  - Controls:
+    - Enter - to select the route for the current player
+    - up / down - cycle through all the available routes
+    - left / right - cycle through all of the players
+    - tab - done with building play; move to confirmation step
+- Third - "Confirmation": confirm the playbook page is done
+  - Controls:
+    - enter - confirms newly created playbook is correct and adds page to the playbook
+    - delete - goes back to routes menu
+- Fourth - "Done": add the page to the playbook
+
+
+#### Run Offensive Plays in Playbook
+View the plays in the offensive playbook with each player running their route.
+- Controls
+  - left / right: cycles through the plays
+  - space - pause/unpuase the running play
+  - enter - restart the play
+
+## Offensive Formations
+
+### Bunch receivers - Quarterback in shotgun
+- Bunch left with no receivers
+- Bunch right with no receivers
+
+### Split running backs - Quarterback in shotgun
+- Reciever on the left
+- Reciever on the right
+
+### Twin receivers - Quarterback in shotgun
+- Twins left with running back on left side
+- Twins left with running back on right side
+- Twins right with Running Back on left side
+- Twins right with Running Back on right side
+
+### Trips receivers - Quarterback in shotgun
+- Trips left with no receivers
+- Trips right with no receivers
+
+## Offensive Routes
+
+### Side Agnostic Routes
+- Block
+- Go
+
+### Left Side Routes
+- Out to sideline
+- Slant - 3 yard
+- Out - 5 yard
+- Out - 10 yard
+- In - 5 yard
+- In - 10 yard
+- Post - 10 yard
+- Whip - 5 yard
+- Out and Up - 7 yard
+
+### Right Side Routes
+- Out to sideline
+- Slant - 3 yard
+- Out - 5 yard
+- Out - 10 yard
+- In - 5 yard
+- In - 10 yard
+- Post - 10 yard
+- Whip - 5 yard
+- Out and Up - 7 yard
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # football-play-simulator
-Program to simulate American Football plays
+
+Program for 7 on 7 American Flag Football teams to build and simulate their playbooks.
 
 ## Menu
 
@@ -9,8 +10,6 @@ Program to simulate American Football plays
 Cycle through the different menus with ESC key
 
 View Plays in Offensive Playbook -> View Offensive Formations -> Build Offensive Playbook -> Run Offensive Plays in Playbook
-/ \
- |___________________________________________________________________________________________________________|
 
 #### View Plays in Offensive Playbook
 View the plays in the default offensive playbook

--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ Flow for building a playbook
     - tab - done with building play; move to confirmation step
 - Third - "Confirmation": confirm the playbook page is done
   - Controls:
-    - enter - confirms newly created playbook is correct and adds page to the playbook
-    - delete - goes back to routes menu
+    - enter - confirms newly created playbook is correct and goes to Done
+    - tab - goes back to routes menu
 - Fourth - "Done": add the page to the playbook
+  - Adds page to the playbook
+  - Saves the playbook to file "Build.playbook
+  - returns back to formation flow
 
 
 #### Run Offensive Plays in Playbook

--- a/formations/formations.go
+++ b/formations/formations.go
@@ -533,19 +533,19 @@ func DrawOffensePlayerRunPlay(imd *imdraw.IMDraw, route routes.OffensePlayRoute,
 func DrawSpecificOffensiveFormation(imd *imdraw.IMDraw, win *pixelgl.Window, iteration int) {
 
 	availableOffensiveFormations := ReturnAllOffensiveTeamFormations()
-	currentFormation := availableOffensiveFormations.Formations[iteration]
+	//currentFormation := availableOffensiveFormations.Formations[iteration]
 	//for i, v := range availableOffensiveFormations.Formations {
 	//	if i < 1 {
 
-	DrawOffensivePlayers(imd, currentFormation)
+	DrawOffensivePlayers(imd, availableOffensiveFormations.Formations[iteration])
 
 	atlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
 	basicTxt := text.New(pixel.V(600, 400), atlas)
 
-	fmt.Fprintln(basicTxt, "Name: "+currentFormation.FormationName)
-	fmt.Fprintln(basicTxt, "Snap Type: "+currentFormation.SnapType)
-	fmt.Fprintln(basicTxt, "Recievers: "+fmt.Sprint(currentFormation.Receivers))
-	fmt.Fprintln(basicTxt, "Running Backs: "+fmt.Sprint(currentFormation.RunningBacks))
+	fmt.Fprintln(basicTxt, "Name: "+availableOffensiveFormations.Formations[iteration].FormationName)
+	fmt.Fprintln(basicTxt, "Snap Type: "+availableOffensiveFormations.Formations[iteration].SnapType)
+	fmt.Fprintln(basicTxt, "Recievers: "+fmt.Sprint(availableOffensiveFormations.Formations[iteration].Receivers))
+	fmt.Fprintln(basicTxt, "Running Backs: "+fmt.Sprint(availableOffensiveFormations.Formations[iteration].RunningBacks))
 
 	basicTxt.Draw(win, pixel.IM)
 

--- a/main.go
+++ b/main.go
@@ -59,12 +59,26 @@ func DrawSpecificOffensiveFormationHighlightOnePlayer(imd *imdraw.IMDraw, win *p
 	DrawOffensivePlayersHighlightOnePlayer(imd, availableOffensiveFormations.Formations[formationIteration], playerHighlight, availableOffensiveRoutes.Routes[routeIteration])
 
 	atlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
-	basicTxt := text.New(pixel.V(600, 400), atlas)
 
-	fmt.Fprintln(basicTxt, "Name: "+availableOffensiveFormations.Formations[formationIteration].FormationName)
-	fmt.Fprintln(basicTxt, "Snap Type: "+availableOffensiveFormations.Formations[formationIteration].SnapType)
-	fmt.Fprintln(basicTxt, "Recievers: "+fmt.Sprint(availableOffensiveFormations.Formations[formationIteration].Receivers))
-	fmt.Fprintln(basicTxt, "Running Backs: "+fmt.Sprint(availableOffensiveFormations.Formations[formationIteration].RunningBacks))
+	playerTxt := text.New(pixel.V(600, 450), atlas)
+	fmt.Fprintln(playerTxt, "Player Information: ")
+	fmt.Fprintln(playerTxt, "Position - "+availableOffensiveFormations.Formations[formationIteration].Players[playerHighlight].Attributes.Position)
+
+	playerTxt.Draw(win, pixel.IM)
+
+	routeTxt := text.New(pixel.V(600, 400), atlas)
+	fmt.Fprintln(routeTxt, "Route Information: ")
+	fmt.Fprintln(routeTxt, "Route Name - "+availableOffensiveRoutes.Routes[routeIteration].RouteName)
+
+	routeTxt.Draw(win, pixel.IM)
+
+	basicTxt := text.New(pixel.V(600, 200), atlas)
+
+	fmt.Fprintln(basicTxt, "Formation Information: ")
+	fmt.Fprintln(basicTxt, "Name - "+availableOffensiveFormations.Formations[formationIteration].FormationName)
+	fmt.Fprintln(basicTxt, "Snap Type - "+availableOffensiveFormations.Formations[formationIteration].SnapType)
+	fmt.Fprintln(basicTxt, "Recievers - "+fmt.Sprint(availableOffensiveFormations.Formations[formationIteration].Receivers))
+	fmt.Fprintln(basicTxt, "Running Backs - "+fmt.Sprint(availableOffensiveFormations.Formations[formationIteration].RunningBacks))
 
 	basicTxt.Draw(win, pixel.IM)
 

--- a/main.go
+++ b/main.go
@@ -383,8 +383,6 @@ func run() {
 
 			win.Clear(colornames.Darkolivegreen)
 
-			//myTeamOffensivePlayBook
-
 			imdBuildOffensivePlaybook.Clear()
 
 			field.DrawFootballFieldYardNumbers(imdFootballField, win)
@@ -463,8 +461,29 @@ func run() {
 					}
 				}
 
+				if win.JustPressed(pixelgl.KeyTab) {
+					BuildOffensivePlaybookMenuSelection = "Confirmation"
+				}
+
+			} else if BuildOffensivePlaybookMenuSelection == "Confirmation" {
+
+				//TODO build a confirmation screen:
+				// Let the user know to use Enter to confirm adding the Play to the playbook
+				// delete to return to editing the play.
+				if win.JustPressed(pixelgl.KeyEnter) {
+					BuildOffensivePlaybookMenuSelection = "Done"
+				} else if win.JustPressed(pixelgl.KeyDelete) {
+					BuildOffensivePlaybookMenuSelection = "Route"
+				}
+
 			} else if BuildOffensivePlaybookMenuSelection == "Done" {
-				playbook.AddPlayBookPage(buildOffensivePlay.PlayName, buildOffensivePlay.Formation, selectedPlayerRoutes.Routes)
+
+				//TODO build a success screen:
+				// Let the user know the play successfully added to the playbook
+				// save playbook
+				// reset everything to add another play to the playbook
+				buildOffensivePlayBook.OffensivePlays = append(buildOffensivePlayBook.OffensivePlays, playbook.AddPlayBookPage(buildOffensivePlay.PlayName, buildOffensivePlay.Formation, selectedPlayerRoutes.Routes))
+
 			}
 
 			win.Update()

--- a/main.go
+++ b/main.go
@@ -173,6 +173,8 @@ func run() {
 	// Build a new playbook
 	var buildOffensivePlayBook playbook.PlayBook
 
+	buildOffensivePlayBook.PlayBookName = "Build"
+
 	myTeamOffensivePlayBook = playbook.BuildDefaultOffensivePlayBook()
 
 	playbook.SavePlayBookToFile(myTeamOffensivePlayBook)
@@ -472,9 +474,11 @@ func run() {
 				// delete to return to editing the play.
 				if win.JustPressed(pixelgl.KeyEnter) {
 					BuildOffensivePlaybookMenuSelection = "Done"
-				} else if win.JustPressed(pixelgl.KeyDelete) {
+				} else if win.JustPressed(pixelgl.KeyTab) {
 					BuildOffensivePlaybookMenuSelection = "Route"
 				}
+
+				playbook.DrawBuildOffensivePlaybookMenuDoneConfirmation(imdBuildOffensivePlaybook, win)
 
 			} else if BuildOffensivePlaybookMenuSelection == "Done" {
 
@@ -483,6 +487,17 @@ func run() {
 				// save playbook
 				// reset everything to add another play to the playbook
 				buildOffensivePlayBook.OffensivePlays = append(buildOffensivePlayBook.OffensivePlays, playbook.AddPlayBookPage(buildOffensivePlay.PlayName, buildOffensivePlay.Formation, selectedPlayerRoutes.Routes))
+
+				//Save the playbook to disk
+				playbook.SavePlayBookToFile(buildOffensivePlayBook)
+
+				//reset all the settings for editing/building a new playbook
+				BuildOffensivePlaybookMenuSelection = "Formation"
+				for i := 0; i < 7; i++ {
+					selectedPlayerRoutes.Routes[i] = routes.DefineBlockRoute()
+				}
+				drawSelectPlayerIteration = 0
+				drawSelectRouteIteration = 0
 
 			}
 

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -2,17 +2,19 @@ package playbook
 
 import (
 	"fmt"
+	"image/color"
 	"jbullfrog81/football-play-simulator/formations"
 	"jbullfrog81/football-play-simulator/routes"
 
 	"encoding/json"
 	"io/ioutil"
 
+	"golang.org/x/image/colornames"
+
 	"github.com/faiface/pixel"
 	"github.com/faiface/pixel/imdraw"
 	"github.com/faiface/pixel/pixelgl"
 	"github.com/faiface/pixel/text"
-	"golang.org/x/image/colornames"
 	"golang.org/x/image/font/basicfont"
 )
 
@@ -89,9 +91,9 @@ func BuildDefaultOffensivePlayBook() PlayBook {
 
 }
 
-func DrawOffensivePlayerPlayRoute(imd *imdraw.IMDraw, playerCoordinates formations.OffensePlayerCoordinates, playerRoutes routes.OffensePlayRoute) {
+func DrawOffensivePlayerPlayRoute(imd *imdraw.IMDraw, playerCoordinates formations.OffensePlayerCoordinates, playerRoutes routes.OffensePlayRoute, routeColor color.RGBA) {
 
-	imd.Color = colornames.Gold
+	imd.Color = routeColor
 
 	for i, _ := range playerRoutes.MinX {
 		playerCoordinates.MinX += playerRoutes.MinX[i]
@@ -107,22 +109,9 @@ func DrawOffensivePlayBookPage(imd *imdraw.IMDraw, win *pixelgl.Window, pageNumb
 
 	for i, v := range offensivePlayBook.OffensivePlays[pageNumber].Formation.Players {
 
-		DrawOffensivePlayerPlayRoute(imd, v.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[i])
+		DrawOffensivePlayerPlayRoute(imd, v.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[i], colornames.Gold)
 
 	}
-	//DrawOffensivePlayerPlayRoute(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation.Player1.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[0])
-
-	//DrawOffensivePlayerPlayRoute(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation.Player2.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[1])
-
-	//DrawOffensivePlayerPlayRoute(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation.Player3.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[2])
-
-	//DrawOffensivePlayerPlayRoute(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation.Player4.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[3])
-
-	//DrawOffensivePlayerPlayRoute(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation.Player5.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[4])
-
-	//DrawOffensivePlayerPlayRoute(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation.Player6.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[5])
-
-	//DrawOffensivePlayerPlayRoute(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation.Player7.Coordinates, offensivePlayBook.OffensivePlays[pageNumber].PlayerRoutes[6])
 
 	formations.DrawOffensivePlayers(imd, offensivePlayBook.OffensivePlays[pageNumber].Formation)
 
@@ -170,4 +159,42 @@ func DrawOffensiveRunPlayMenu(imd *imdraw.IMDraw, win *pixelgl.Window, offensive
 	fmt.Fprintln(basicTxt, "Running Backs: "+fmt.Sprint(offensivePlayBook.OffensivePlays[pageNumber].Formation.RunningBacks))
 
 	basicTxt.Draw(win, pixel.IM)
+}
+
+func DrawBuildOffensivePlaybookMenu(imd *imdraw.IMDraw, win *pixelgl.Window) {
+
+	atlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
+	basicTxtMenu := text.New(pixel.V(600, 600), atlas)
+
+	fmt.Fprintln(basicTxtMenu, "Build Offensive Playbook Menu:")
+	basicTxtMenu.Draw(win, pixel.IM.Scaled(basicTxtMenu.Orig, 2))
+
+}
+
+func DrawBuildOffensivePlaybookMenuSelectFormation(imd *imdraw.IMDraw, win *pixelgl.Window, formationIteration int) {
+
+	//formationIteration = 0
+
+	DrawBuildOffensivePlaybookMenu(imd, win)
+
+	atlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
+	basicTxtMenuSelectFormation := text.New(pixel.V(600, 500), atlas)
+
+	fmt.Fprintln(basicTxtMenuSelectFormation, "Select your formation:")
+	basicTxtMenuSelectFormation.Draw(win, pixel.IM)
+
+	formations.DrawSpecificOffensiveFormation(imd, win, formationIteration)
+
+}
+
+func DrawBuildOffensivePlaybookMenuSelectRoute(imd *imdraw.IMDraw, win *pixelgl.Window, formationIteration int, routeIteration int, selectedPlayer int) {
+
+	DrawBuildOffensivePlaybookMenu(imd, win)
+
+	atlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
+	basicTxtMenuSelectFormation := text.New(pixel.V(600, 500), atlas)
+
+	fmt.Fprintln(basicTxtMenuSelectFormation, "Select your player route:")
+	basicTxtMenuSelectFormation.Draw(win, pixel.IM)
+
 }

--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -198,3 +198,17 @@ func DrawBuildOffensivePlaybookMenuSelectRoute(imd *imdraw.IMDraw, win *pixelgl.
 	basicTxtMenuSelectFormation.Draw(win, pixel.IM)
 
 }
+
+func DrawBuildOffensivePlaybookMenuDoneConfirmation(imd *imdraw.IMDraw, win *pixelgl.Window) {
+
+	DrawBuildOffensivePlaybookMenu(imd, win)
+
+	atlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
+	basicTxtMenuSelectFormation := text.New(pixel.V(600, 500), atlas)
+
+	fmt.Fprintln(basicTxtMenuSelectFormation, "Are you sure you're done with your play?")
+	fmt.Fprintln(basicTxtMenuSelectFormation, "Press enter to save")
+	fmt.Fprintln(basicTxtMenuSelectFormation, "Press tab to go back to edit")
+	basicTxtMenuSelectFormation.Draw(win, pixel.IM)
+
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -7,6 +7,82 @@ type OffensePlayRoute struct {
 	MaxY []float64
 }
 
+type OffensePlayRoutes struct {
+	Routes []OffensePlayRoute
+}
+
+func ReturnAllOffensePlayRoutes() (allRoutes OffensePlayRoutes) {
+
+	var route OffensePlayRoute
+
+	// TODO: figure out how to iterate through a slice of all route functions
+	// to generate all of the routes
+	//var sliceOfRoutes := {"","",}
+
+	route = DefineBlockRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineGoRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightSlantThreeYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightOutFiveYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightOutTenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightInFiveYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightInTenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightPostTenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightWhipSevenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightWhipFiveYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineRightOutAndUpSevenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftSlantThreeYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftOutFiveYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftOutTenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftInFiveYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftInTenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftPostTenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftWhipSevenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftWhipFiveYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftOutAndUpSevenYardRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	return allRoutes
+
+}
+
 // Field Side Agnostic Routes
 
 func DefineBlockRoute() OffensePlayRoute {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -336,6 +336,13 @@ func DefineRightWhipSevenYardRoute() OffensePlayRoute {
 		route.MaxY = append(route.MaxY, float64(0))
 	}
 
+	for i := 0; i < 5; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
+	}
+
 	for i := 0; i < 101; i++ {
 		route.MinX = append(route.MinX, float64(1))
 		route.MinY = append(route.MinY, float64(0))
@@ -374,6 +381,13 @@ func DefineRightWhipFiveYardRoute() OffensePlayRoute {
 		route.MinY = append(route.MinY, float64(0))
 		route.MaxX = append(route.MaxX, float64(-1))
 		route.MaxY = append(route.MaxY, float64(0))
+	}
+
+	for i := 0; i < 5; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
 	}
 
 	for i := 0; i < 101; i++ {
@@ -666,6 +680,13 @@ func DefineLeftWhipSevenYardRoute() OffensePlayRoute {
 		route.MaxY = append(route.MaxY, float64(0))
 	}
 
+	for i := 0; i < 5; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
+	}
+
 	for i := 0; i < 101; i++ {
 		route.MinX = append(route.MinX, float64(-1))
 		route.MinY = append(route.MinY, float64(0))
@@ -704,6 +725,13 @@ func DefineLeftWhipFiveYardRoute() OffensePlayRoute {
 		route.MinY = append(route.MinY, float64(0))
 		route.MaxX = append(route.MaxX, float64(1))
 		route.MaxY = append(route.MaxY, float64(0))
+	}
+
+	for i := 0; i < 5; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
 	}
 
 	for i := 0; i < 101; i++ {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,10 +1,11 @@
 package routes
 
 type OffensePlayRoute struct {
-	MinX []float64
-	MinY []float64
-	MaxX []float64
-	MaxY []float64
+	RouteName string
+	MinX      []float64
+	MinY      []float64
+	MaxX      []float64
+	MaxY      []float64
 }
 
 type OffensePlayRoutes struct {
@@ -93,6 +94,7 @@ func DefineBlockRoute() OffensePlayRoute {
 	route.MinY = append(route.MinY, float64(0))
 	route.MaxX = append(route.MaxX, float64(0))
 	route.MaxY = append(route.MaxY, float64(0))
+	route.RouteName = "Block"
 
 	return route
 
@@ -101,6 +103,8 @@ func DefineBlockRoute() OffensePlayRoute {
 func DefineGoRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "Go"
 
 	for i := 0; i < 201; i++ {
 		route.MinX = append(route.MinX, float64(0))
@@ -118,6 +122,8 @@ func DefineGoRoute() OffensePlayRoute {
 func DefineRightSlantThreeYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "3 yd Right Slant"
 
 	//var values OffensePlayRoute
 
@@ -143,6 +149,8 @@ func DefineRightOutFiveYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "5 yd Out - Right Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 51; i++ {
@@ -166,6 +174,8 @@ func DefineRightOutFiveYardRoute() OffensePlayRoute {
 func DefineRightOutTenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "10 yd Out - Right Side"
 
 	//var values OffensePlayRoute
 
@@ -191,6 +201,8 @@ func DefineRightInFiveYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "5 yd In - Right Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 51; i++ {
@@ -214,6 +226,8 @@ func DefineRightInFiveYardRoute() OffensePlayRoute {
 func DefineRightInTenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "10 yd In - Right Side"
 
 	//var values OffensePlayRoute
 
@@ -239,6 +253,8 @@ func DefineRightPostTenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "10 yd Post - Right Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 101; i++ {
@@ -262,6 +278,8 @@ func DefineRightPostTenYardRoute() OffensePlayRoute {
 func DefineRightWhipSevenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "7 yd Whip - Right Side"
 
 	//var values OffensePlayRoute
 
@@ -301,6 +319,8 @@ func DefineRightWhipFiveYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "5 yd Whip - Right Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 41; i++ {
@@ -339,6 +359,8 @@ func DefineRightOutAndUpSevenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "7 yd Out and Up - Right Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 71; i++ {
@@ -372,6 +394,8 @@ func DefineLeftSlantThreeYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "3 yd Slant - Left Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 31; i++ {
@@ -395,6 +419,8 @@ func DefineLeftSlantThreeYardRoute() OffensePlayRoute {
 func DefineLeftOutFiveYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "5 yd Out - Left Side"
 
 	//var values OffensePlayRoute
 
@@ -420,6 +446,8 @@ func DefineLeftOutTenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "10 yd Out - Left Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 101; i++ {
@@ -443,6 +471,8 @@ func DefineLeftOutTenYardRoute() OffensePlayRoute {
 func DefineLeftInFiveYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "5 yd In - Left Side"
 
 	//var values OffensePlayRoute
 
@@ -468,6 +498,8 @@ func DefineLeftInTenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "10 yd In - Left Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 101; i++ {
@@ -492,6 +524,8 @@ func DefineLeftPostTenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "10 yd Post - Left Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 101; i++ {
@@ -515,6 +549,8 @@ func DefineLeftPostTenYardRoute() OffensePlayRoute {
 func DefineLeftWhipSevenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "7 yd Whip - Left Side"
 
 	//var values OffensePlayRoute
 
@@ -554,6 +590,8 @@ func DefineLeftWhipFiveYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
+	route.RouteName = "5 yd Whip - Left Side"
+
 	//var values OffensePlayRoute
 
 	for i := 0; i < 41; i++ {
@@ -591,6 +629,8 @@ func DefineLeftWhipFiveYardRoute() OffensePlayRoute {
 func DefineLeftOutAndUpSevenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
+
+	route.RouteName = "7 yd Out and Up - Left Side"
 
 	//var values OffensePlayRoute
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -20,6 +20,12 @@ func ReturnAllOffensePlayRoutes() (allRoutes OffensePlayRoutes) {
 	// to generate all of the routes
 	//var sliceOfRoutes := {"","",}
 
+	route = DefineRightOutToSidelineRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
+	route = DefineLeftOutToSidelineRoute()
+	allRoutes.Routes = append(allRoutes.Routes, route)
+
 	route = DefineBlockRoute()
 	allRoutes.Routes = append(allRoutes.Routes, route)
 
@@ -119,11 +125,37 @@ func DefineGoRoute() OffensePlayRoute {
 
 // Right Side Field Routes
 
+func DefineRightOutToSidelineRoute() OffensePlayRoute {
+
+	var route OffensePlayRoute
+
+	route.RouteName = "Right Out to Side Line"
+
+	//var values OffensePlayRoute
+
+	for i := 0; i < 31; i++ {
+		route.MinX = append(route.MinX, float64(1))
+		route.MinY = append(route.MinY, float64(0))
+		route.MaxX = append(route.MaxX, float64(1))
+		route.MaxY = append(route.MaxY, float64(0))
+	}
+
+	for i := 0; i < 101; i++ {
+		route.MinX = append(route.MinX, float64(1))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(1))
+		route.MaxY = append(route.MaxY, float64(1))
+	}
+
+	return route
+
+}
+
 func DefineRightSlantThreeYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
 
-	route.RouteName = "3 yd Right Slant"
+	route.RouteName = "3 yd Slant - Right Side"
 
 	//var values OffensePlayRoute
 
@@ -355,6 +387,39 @@ func DefineRightWhipFiveYardRoute() OffensePlayRoute {
 
 }
 
+func DefineRightOutAndUpFiveYardRoute() OffensePlayRoute {
+
+	var route OffensePlayRoute
+
+	route.RouteName = "5 yd Out and Up - Right Side"
+
+	//var values OffensePlayRoute
+
+	for i := 0; i < 51; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
+	}
+
+	for i := 0; i < 51; i++ {
+		route.MinX = append(route.MinX, float64(1))
+		route.MinY = append(route.MinY, float64(0))
+		route.MaxX = append(route.MaxX, float64(1))
+		route.MaxY = append(route.MaxY, float64(0))
+	}
+
+	for i := 0; i < 101; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
+	}
+
+	return route
+
+}
+
 func DefineRightOutAndUpSevenYardRoute() OffensePlayRoute {
 
 	var route OffensePlayRoute
@@ -389,6 +454,32 @@ func DefineRightOutAndUpSevenYardRoute() OffensePlayRoute {
 }
 
 // Left Side Field Routes
+
+func DefineLeftOutToSidelineRoute() OffensePlayRoute {
+
+	var route OffensePlayRoute
+
+	route.RouteName = "Left Out to Side Line"
+
+	//var values OffensePlayRoute
+
+	for i := 0; i < 31; i++ {
+		route.MinX = append(route.MinX, float64(-1))
+		route.MinY = append(route.MinY, float64(0))
+		route.MaxX = append(route.MaxX, float64(-1))
+		route.MaxY = append(route.MaxY, float64(0))
+	}
+
+	for i := 0; i < 101; i++ {
+		route.MinX = append(route.MinX, float64(-1))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(-1))
+		route.MaxY = append(route.MaxY, float64(1))
+	}
+
+	return route
+
+}
 
 func DefineLeftSlantThreeYardRoute() OffensePlayRoute {
 
@@ -554,14 +645,14 @@ func DefineLeftWhipSevenYardRoute() OffensePlayRoute {
 
 	//var values OffensePlayRoute
 
-	for i := 0; i < 71; i++ {
+	for i := 0; i < 51; i++ {
 		route.MinX = append(route.MinX, float64(0))
 		route.MinY = append(route.MinY, float64(1))
 		route.MaxX = append(route.MaxX, float64(0))
 		route.MaxY = append(route.MaxY, float64(1))
 	}
 
-	for i := 0; i < 51; i++ {
+	for i := 0; i < 21; i++ {
 		route.MinX = append(route.MinX, float64(1))
 		route.MinY = append(route.MinY, float64(1))
 		route.MaxX = append(route.MaxX, float64(1))
@@ -620,6 +711,39 @@ func DefineLeftWhipFiveYardRoute() OffensePlayRoute {
 		route.MinY = append(route.MinY, float64(0))
 		route.MaxX = append(route.MaxX, float64(-1))
 		route.MaxY = append(route.MaxY, float64(0))
+	}
+
+	return route
+
+}
+
+func DefineLeftOutAndUpFiveYardRoute() OffensePlayRoute {
+
+	var route OffensePlayRoute
+
+	route.RouteName = "5 yd Out and Up - Left Side"
+
+	//var values OffensePlayRoute
+
+	for i := 0; i < 51; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
+	}
+
+	for i := 0; i < 51; i++ {
+		route.MinX = append(route.MinX, float64(-1))
+		route.MinY = append(route.MinY, float64(0))
+		route.MaxX = append(route.MaxX, float64(-1))
+		route.MaxY = append(route.MaxY, float64(0))
+	}
+
+	for i := 0; i < 101; i++ {
+		route.MinX = append(route.MinX, float64(0))
+		route.MinY = append(route.MinY, float64(1))
+		route.MaxX = append(route.MaxX, float64(0))
+		route.MaxY = append(route.MaxY, float64(1))
 	}
 
 	return route


### PR DESCRIPTION
In this PR:
- Added functionality to build a playbook
  - Esc key will move to menu option RunPlay
  - Process for building a playbook
    - User selects a formation
      - user key input
        - enter - move to next step (select route for each player)
        - up / down - cycle through all the available formations
    - User selects the route per player in the formation
      - Cycle through all routes with the up and down keys
      - Route is displayed in red on the field in front of the player
      - Shows selected routes for each player in yellow
      - user key inputs
        - Enter - to select the route for the current player
        - up / down - cycle through all the available routes
        - left / right - cycle through all of the players
        - tab - confirmation that 
   - Add Confirmation and Done steps to building a new offensive playbook
     - user key inputs:
       - enter
         - confirms newly created playbook is correct
         - adds page to the playbook
       - delete - goes back to routes menu
- Routes
  - Added
    - 5 yard Out and Up
    - 5 yard whip
    - Out to sideline route
    - function to return all of the routes
    - route names
  - Modified
    - Whip
      - added up half a yard to see the route more clearly