### PR TITLE
Bug: PDF - player no route wrong outline

### DIFF
--- a/playbook/playbook.go
+++ b/playbook/playbook.go
@@ -208,16 +208,17 @@ func CreateOffensivePlaybookPdf(pdf *gofpdf.Fpdf, offensivePlaybook PlayBook) {
 
 			}
 
+			// set the width of the route line for easier viewing
+			pdf.SetLineWidth(1)
+			// set the color of the route for the player
+			pdf.SetDrawColor(int(playerValue.Attributes.Color.R), int(playerValue.Attributes.Color.G), int(playerValue.Attributes.Color.B))
+
 			//draw the route for the player
 			for i, _ := range scaledRouteX {
 				xNew += scaledRouteX[i]
 				yNew += scaledRouteY[i]
 				//this will ensure that the playroute doesn't print outside the play boxes
 				if i < len(scaledRouteX) && (xNew < footballLocationX+(playOutlinesWidth/2) && xNew > footballLocationX-(playOutlinesWidth/2)) && (yNew < footballLocationY+(playOutlinesHeight/2) && yNew > footballLocationY-(playOutlinesHeight/2)) {
-					// set the width of the route line for easier viewing
-					pdf.SetLineWidth(1)
-					// set the color of the route for the player
-					pdf.SetDrawColor(int(playerValue.Attributes.Color.R), int(playerValue.Attributes.Color.G), int(playerValue.Attributes.Color.B))
 					// draw the route for the player
 					pdf.Line(xCurrent, yCurrent, xNew, yNew)
 				}


### PR DESCRIPTION
In this PR:
- Fixed the bug where a player with no route will have the wrong outline

Before:
<img width="172" alt="image" src="https://user-images.githubusercontent.com/13921371/158036741-20d6e647-e331-497d-9f1b-3e78ef9a5dec.png">

After:
<img width="176" alt="image" src="https://user-images.githubusercontent.com/13921371/158036750-992224ac-da1f-42c8-988d-cedeb417f60d.png">
